### PR TITLE
Fix concatenated extensions

### DIFF
--- a/src/bin2header.py
+++ b/src/bin2header.py
@@ -74,7 +74,7 @@ def main(argv):
 		sys.exit(1)
 
 	### Get filenames and target directory ###
-	filename = list(GetBaseName(source_file))
+	filename, file_extension = os.path.splitext(source_file)
 	hname = list(filename)
 	target_dir = GetDirName(source_file)
 


### PR DESCRIPTION
The python app is generating a file 'MyFile.bin.h' when it has the '.bin' extension for example.